### PR TITLE
feat: 音源切换、多 API Key、会话导出 Markdown

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -33,10 +34,10 @@
         <service
             android:name=".service.SubtitleSessionService"
             android:exported="false"
-            android:foregroundServiceType="mediaProjection|specialUse">
+            android:foregroundServiceType="mediaProjection|microphone|specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="Real-time floating subtitle overlay while capturing system audio for translation" />
+                android:value="Real-time floating subtitle overlay while capturing system or microphone audio for translation" />
         </service>
     </application>
 </manifest>

--- a/app/src/main/java/com/livetranslate/app/audio/MicAudioCapturer.kt
+++ b/app/src/main/java/com/livetranslate/app/audio/MicAudioCapturer.kt
@@ -1,10 +1,9 @@
 package com.livetranslate.app.audio
 
-import android.media.AudioAttributes
+import android.annotation.SuppressLint
 import android.media.AudioFormat
-import android.media.AudioPlaybackCaptureConfiguration
 import android.media.AudioRecord
-import android.media.projection.MediaProjection
+import android.media.MediaRecorder
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -13,10 +12,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 /**
- * Captures other apps' media playback via AudioPlaybackCapture (API 29+),
- * then downsamples to 16-bit mono PCM @ 16 kHz for Live Translate.
+ * Captures microphone PCM and resamples to 16 kHz mono LE for Live Translate.
  */
-class SystemAudioCapturer(
+class MicAudioCapturer(
     private val scope: CoroutineScope,
 ) {
     private var audioRecord: AudioRecord? = null
@@ -25,38 +23,25 @@ class SystemAudioCapturer(
     @Volatile
     private var running = false
 
-    fun start(
-        mediaProjection: MediaProjection,
-        onPcm16k: (ByteArray) -> Unit,
-    ) {
+    @SuppressLint("MissingPermission")
+    fun start(onPcm16k: (ByteArray) -> Unit) {
         stop()
-        val captureConfig = AudioPlaybackCaptureConfiguration.Builder(mediaProjection)
-            .addMatchingUsage(AudioAttributes.USAGE_MEDIA)
-            .addMatchingUsage(AudioAttributes.USAGE_GAME)
-            .addMatchingUsage(AudioAttributes.USAGE_UNKNOWN)
-            .build()
-
         val sourceRate = 44_100
         val channelConfig = AudioFormat.CHANNEL_IN_MONO
         val encoding = AudioFormat.ENCODING_PCM_16BIT
         val minBuf = AudioRecord.getMinBufferSize(sourceRate, channelConfig, encoding)
         val bufferSize = (minBuf * 2).coerceAtLeast(sourceRate / 5 * 2)
 
-        val record = AudioRecord.Builder()
-            .setAudioFormat(
-                AudioFormat.Builder()
-                    .setEncoding(encoding)
-                    .setSampleRate(sourceRate)
-                    .setChannelMask(channelConfig)
-                    .build(),
-            )
-            .setBufferSizeInBytes(bufferSize)
-            .setAudioPlaybackCaptureConfig(captureConfig)
-            .build()
-
+        val record = AudioRecord(
+            MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            sourceRate,
+            channelConfig,
+            encoding,
+            bufferSize,
+        )
         if (record.state != AudioRecord.STATE_INITIALIZED) {
             record.release()
-            throw IllegalStateException("AudioRecord 初始化失败，无法内录系统音频")
+            throw IllegalStateException("麦克风 AudioRecord 初始化失败")
         }
 
         audioRecord = record
@@ -72,7 +57,7 @@ class SystemAudioCapturer(
                     val pcm16k = resampler.resample(readBuf, n)
                     if (pcm16k.isNotEmpty()) onPcm16k(pcm16k)
                 } else if (n < 0) {
-                    Log.w(TAG, "AudioRecord read error: $n")
+                    Log.w(TAG, "mic read error: $n")
                     break
                 }
             }
@@ -92,6 +77,6 @@ class SystemAudioCapturer(
     }
 
     companion object {
-        private const val TAG = "SystemAudioCapturer"
+        private const val TAG = "MicAudioCapturer"
     }
 }

--- a/app/src/main/java/com/livetranslate/app/audio/PcmMixer.kt
+++ b/app/src/main/java/com/livetranslate/app/audio/PcmMixer.kt
@@ -1,0 +1,71 @@
+package com.livetranslate.app.audio
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Mixes two 16 kHz mono PCM16 LE streams (media + mic) by averaging samples.
+ * Soft-starts with ring-ish queues; drops lag when one side runs far ahead.
+ */
+class PcmMixer(
+    private val onMixed: (ByteArray) -> Unit,
+) {
+    private val mediaQ = ConcurrentLinkedQueue<Byte>()
+    private val micQ = ConcurrentLinkedQueue<Byte>()
+    private val closed = AtomicBoolean(false)
+
+    fun offerMedia(chunk: ByteArray) {
+        if (closed.get()) return
+        chunk.forEach { mediaQ.offer(it) }
+        drain()
+    }
+
+    fun offerMic(chunk: ByteArray) {
+        if (closed.get()) return
+        chunk.forEach { micQ.offer(it) }
+        drain()
+    }
+
+    fun close() {
+        closed.set(true)
+        mediaQ.clear()
+        micQ.clear()
+    }
+
+    private fun drain() {
+        // Keep queues from growing unbounded (~1s @ 16k mono 16bit = 32000 bytes)
+        trim(mediaQ, MAX_QUEUE_BYTES)
+        trim(micQ, MAX_QUEUE_BYTES)
+
+        val frames = minOf(mediaQ.size / 2, micQ.size / 2)
+        if (frames <= 0) return
+        val out = ByteArray(frames * 2)
+        var oi = 0
+        repeat(frames) {
+            val m0 = mediaQ.poll()?.toInt()?.and(0xFF) ?: return
+            val m1 = mediaQ.poll()?.toInt() ?: return
+            val n0 = micQ.poll()?.toInt()?.and(0xFF) ?: return
+            val n1 = micQ.poll()?.toInt() ?: return
+            val ms = (m1 shl 8) or m0
+            val ns = (n1 shl 8) or n0
+            val mSigned = ms.toShort().toInt()
+            val nSigned = ns.toShort().toInt()
+            val mixed = ((mSigned + nSigned) / 2)
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            out[oi++] = (mixed and 0xFF).toByte()
+            out[oi++] = ((mixed shr 8) and 0xFF).toByte()
+        }
+        if (oi > 0) onMixed(if (oi == out.size) out else out.copyOf(oi))
+    }
+
+    private fun trim(q: ConcurrentLinkedQueue<Byte>, max: Int) {
+        while (q.size > max) {
+            q.poll()
+            q.poll() // drop whole sample when possible
+        }
+    }
+
+    companion object {
+        private const val MAX_QUEUE_BYTES = 48_000
+    }
+}

--- a/app/src/main/java/com/livetranslate/app/audio/PcmResampler.kt
+++ b/app/src/main/java/com/livetranslate/app/audio/PcmResampler.kt
@@ -1,0 +1,37 @@
+package com.livetranslate.app.audio
+
+import kotlin.math.min
+
+/**
+ * Linear resampler: short[] @ fromRate -> ByteArray LE PCM16 @ toRate.
+ */
+class PcmResampler(
+    private val fromRate: Int,
+    private val toRate: Int,
+) {
+    private var position = 0.0
+    private val step = fromRate.toDouble() / toRate.toDouble()
+
+    fun resample(input: ShortArray, length: Int): ByteArray {
+        if (length <= 0) return ByteArray(0)
+        val outCount = ((length / step).toInt() + 2).coerceAtLeast(1)
+        val out = ByteArray(outCount * 2)
+        var outIndex = 0
+        var pos = position
+        while (pos < length - 1) {
+            val i = pos.toInt()
+            val frac = pos - i
+            val s0 = input[i].toInt()
+            val s1 = input[min(i + 1, length - 1)].toInt()
+            val sample = (s0 + (s1 - s0) * frac).toInt()
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            if (outIndex + 1 >= out.size) break
+            out[outIndex++] = (sample and 0xFF).toByte()
+            out[outIndex++] = ((sample shr 8) and 0xFF).toByte()
+            pos += step
+        }
+        position = pos - length
+        if (position < 0) position = 0.0
+        return if (outIndex == out.size) out else out.copyOf(outIndex)
+    }
+}

--- a/app/src/main/java/com/livetranslate/app/data/ApiKeyStore.kt
+++ b/app/src/main/java/com/livetranslate/app/data/ApiKeyStore.kt
@@ -5,21 +5,81 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import org.json.JSONArray
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * API Key storage. Prefers EncryptedSharedPreferences; falls back to private prefs
- * if Keystore/crypto init fails (some ROMs crash otherwise).
+ * Stores up to [MAX_KEYS] API keys (encrypted when possible) and supports rotation.
  */
 class ApiKeyStore(context: Context) {
     private val prefs: SharedPreferences = createPrefs(context.applicationContext)
+    private val rotateIndex = AtomicInteger(0)
 
-    fun getApiKey(): String = prefs.getString(KEY_API, "").orEmpty()
-
-    fun setApiKey(value: String) {
-        prefs.edit().putString(KEY_API, value.trim()).apply()
+    fun getApiKeys(): List<String> {
+        val raw = prefs.getString(KEY_API_LIST, null)
+        if (!raw.isNullOrBlank()) {
+            return runCatching {
+                val arr = JSONArray(raw)
+                buildList {
+                    for (i in 0 until arr.length()) {
+                        val s = arr.optString(i).trim()
+                        if (s.isNotEmpty()) add(s)
+                    }
+                }
+            }.getOrDefault(emptyList()).ifEmpty {
+                // migrate legacy single key
+                val legacy = prefs.getString(KEY_API, "").orEmpty().trim()
+                if (legacy.isNotEmpty()) listOf(legacy) else emptyList()
+            }
+        }
+        val legacy = prefs.getString(KEY_API, "").orEmpty().trim()
+        return if (legacy.isNotEmpty()) listOf(legacy) else emptyList()
     }
 
-    fun hasApiKey(): Boolean = getApiKey().isNotBlank()
+    fun setApiKeys(keys: List<String>) {
+        val cleaned = keys.map { it.trim() }.filter { it.isNotEmpty() }.take(MAX_KEYS)
+        val arr = JSONArray()
+        cleaned.forEach { arr.put(it) }
+        prefs.edit()
+            .putString(KEY_API_LIST, arr.toString())
+            .putString(KEY_API, cleaned.firstOrNull().orEmpty()) // keep legacy field in sync
+            .apply()
+        if (cleaned.isEmpty()) {
+            rotateIndex.set(0)
+        } else {
+            rotateIndex.updateAndGet { it.coerceIn(0, cleaned.lastIndex) }
+        }
+    }
+
+    /** Legacy helpers used by older call sites. */
+    fun getApiKey(): String = getApiKeys().firstOrNull().orEmpty()
+
+    fun setApiKey(value: String) {
+        val rest = getApiKeys().drop(1)
+        setApiKeys(listOf(value.trim()).filter { it.isNotEmpty() } + rest)
+    }
+
+    fun hasApiKey(): Boolean = getApiKeys().isNotEmpty()
+
+    /**
+     * Round-robin pick for a new session. Empty string if none.
+     */
+    fun nextRotatedKey(): String {
+        val keys = getApiKeys()
+        if (keys.isEmpty()) return ""
+        val i = rotateIndex.getAndUpdate { (it + 1) % keys.size }
+        return keys[i % keys.size]
+    }
+
+    /**
+     * Try keys starting from [startIndex] (inclusive) for connection test / failover.
+     */
+    fun keysFrom(startIndex: Int = 0): List<String> {
+        val keys = getApiKeys()
+        if (keys.isEmpty()) return emptyList()
+        val start = startIndex.coerceIn(0, keys.lastIndex)
+        return keys.drop(start) + keys.take(start)
+    }
 
     private fun createPrefs(context: Context): SharedPreferences {
         return try {
@@ -43,5 +103,7 @@ class ApiKeyStore(context: Context) {
         private const val FILE_NAME_ENCRYPTED = "secure_api_prefs"
         private const val FILE_NAME_FALLBACK = "api_prefs_fallback"
         private const val KEY_API = "api_key"
+        private const val KEY_API_LIST = "api_key_list"
+        const val MAX_KEYS = 10
     }
 }

--- a/app/src/main/java/com/livetranslate/app/data/AudioSourceMode.kt
+++ b/app/src/main/java/com/livetranslate/app/data/AudioSourceMode.kt
@@ -1,0 +1,27 @@
+package com.livetranslate.app.data
+
+/**
+ * Where PCM for Live Translate comes from.
+ */
+enum class AudioSourceMode {
+    /** Other apps' media playback only (MediaProjection capture). */
+    MEDIA,
+
+    /** Device microphone only. */
+    MIC,
+
+    /** Mix media playback + microphone. */
+    MEDIA_AND_MIC,
+    ;
+
+    val needsMediaProjection: Boolean
+        get() = this == MEDIA || this == MEDIA_AND_MIC
+
+    val needsMicrophone: Boolean
+        get() = this == MIC || this == MEDIA_AND_MIC
+
+    companion object {
+        fun fromStorage(raw: String?): AudioSourceMode =
+            entries.firstOrNull { it.name == raw } ?: MEDIA
+    }
+}

--- a/app/src/main/java/com/livetranslate/app/data/UserSettings.kt
+++ b/app/src/main/java/com/livetranslate/app/data/UserSettings.kt
@@ -20,6 +20,7 @@ data class UserSettings(
     val overlayY: Int = Defaults.OVERLAY_Y,
     val overlayWidthDp: Int = Defaults.OVERLAY_WIDTH_DP,
     val overlayHeightDp: Int = Defaults.OVERLAY_HEIGHT_DP,
+    val audioSourceMode: AudioSourceMode = Defaults.AUDIO_SOURCE,
 ) {
     object Defaults {
         const val ENDPOINT =
@@ -36,6 +37,7 @@ data class UserSettings(
         const val OVERLAY_Y = -1
         const val OVERLAY_WIDTH_DP = 360
         const val OVERLAY_HEIGHT_DP = 120
+        val AUDIO_SOURCE: AudioSourceMode = AudioSourceMode.MEDIA
     }
 }
 

--- a/app/src/main/java/com/livetranslate/app/data/UserSettingsRepository.kt
+++ b/app/src/main/java/com/livetranslate/app/data/UserSettingsRepository.kt
@@ -29,48 +29,16 @@ class UserSettingsRepository(private val context: Context) {
         val overlayY = intPreferencesKey("overlay_y")
         val overlayWidthDp = intPreferencesKey("overlay_width_dp")
         val overlayHeightDp = intPreferencesKey("overlay_height_dp")
+        val audioSourceMode = stringPreferencesKey("audio_source_mode")
     }
 
     val settings: Flow<UserSettings> = context.dataStore.data.map { prefs ->
-        UserSettings(
-            endpoint = prefs[Keys.endpoint] ?: UserSettings.Defaults.ENDPOINT,
-            modelId = prefs[Keys.modelId] ?: UserSettings.Defaults.MODEL_ID,
-            sourceLanguageCode = prefs[Keys.sourceLanguage] ?: UserSettings.Defaults.SOURCE_LANGUAGE,
-            targetLanguageCode = prefs[Keys.targetLanguage] ?: UserSettings.Defaults.TARGET_LANGUAGE,
-            fontSizeSp = prefs[Keys.fontSizeSp] ?: UserSettings.Defaults.FONT_SIZE_SP,
-            backgroundAlpha = prefs[Keys.backgroundAlpha] ?: UserSettings.Defaults.BACKGROUND_ALPHA,
-            bilingual = prefs[Keys.bilingual] ?: UserSettings.Defaults.BILINGUAL,
-            playTranslatedAudio = prefs[Keys.playTranslatedAudio]
-                ?: UserSettings.Defaults.PLAY_TRANSLATED_AUDIO,
-            translatedVolume = prefs[Keys.translatedVolume] ?: UserSettings.Defaults.TRANSLATED_VOLUME,
-            overlayX = prefs[Keys.overlayX] ?: UserSettings.Defaults.OVERLAY_X,
-            overlayY = prefs[Keys.overlayY] ?: UserSettings.Defaults.OVERLAY_Y,
-            overlayWidthDp = prefs[Keys.overlayWidthDp] ?: UserSettings.Defaults.OVERLAY_WIDTH_DP,
-            overlayHeightDp = prefs[Keys.overlayHeightDp] ?: UserSettings.Defaults.OVERLAY_HEIGHT_DP,
-        )
+        prefs.toSettings()
     }
 
     suspend fun update(transform: (UserSettings) -> UserSettings) {
         context.dataStore.edit { prefs ->
-            val current = UserSettings(
-                endpoint = prefs[Keys.endpoint] ?: UserSettings.Defaults.ENDPOINT,
-                modelId = prefs[Keys.modelId] ?: UserSettings.Defaults.MODEL_ID,
-                sourceLanguageCode = prefs[Keys.sourceLanguage] ?: UserSettings.Defaults.SOURCE_LANGUAGE,
-                targetLanguageCode = prefs[Keys.targetLanguage] ?: UserSettings.Defaults.TARGET_LANGUAGE,
-                fontSizeSp = prefs[Keys.fontSizeSp] ?: UserSettings.Defaults.FONT_SIZE_SP,
-                backgroundAlpha = prefs[Keys.backgroundAlpha] ?: UserSettings.Defaults.BACKGROUND_ALPHA,
-                bilingual = prefs[Keys.bilingual] ?: UserSettings.Defaults.BILINGUAL,
-                playTranslatedAudio = prefs[Keys.playTranslatedAudio]
-                    ?: UserSettings.Defaults.PLAY_TRANSLATED_AUDIO,
-                translatedVolume = prefs[Keys.translatedVolume]
-                    ?: UserSettings.Defaults.TRANSLATED_VOLUME,
-                overlayX = prefs[Keys.overlayX] ?: UserSettings.Defaults.OVERLAY_X,
-                overlayY = prefs[Keys.overlayY] ?: UserSettings.Defaults.OVERLAY_Y,
-                overlayWidthDp = prefs[Keys.overlayWidthDp] ?: UserSettings.Defaults.OVERLAY_WIDTH_DP,
-                overlayHeightDp = prefs[Keys.overlayHeightDp]
-                    ?: UserSettings.Defaults.OVERLAY_HEIGHT_DP,
-            )
-            val next = transform(current)
+            val next = transform(prefs.toSettings())
             prefs[Keys.endpoint] = next.endpoint
             prefs[Keys.modelId] = next.modelId
             prefs[Keys.sourceLanguage] = next.sourceLanguageCode
@@ -84,6 +52,7 @@ class UserSettingsRepository(private val context: Context) {
             prefs[Keys.overlayY] = next.overlayY
             prefs[Keys.overlayWidthDp] = next.overlayWidthDp
             prefs[Keys.overlayHeightDp] = next.overlayHeightDp
+            prefs[Keys.audioSourceMode] = next.audioSourceMode.name
         }
     }
 
@@ -96,4 +65,22 @@ class UserSettingsRepository(private val context: Context) {
             )
         }
     }
+
+    private fun Preferences.toSettings(): UserSettings = UserSettings(
+        endpoint = this[Keys.endpoint] ?: UserSettings.Defaults.ENDPOINT,
+        modelId = this[Keys.modelId] ?: UserSettings.Defaults.MODEL_ID,
+        sourceLanguageCode = this[Keys.sourceLanguage] ?: UserSettings.Defaults.SOURCE_LANGUAGE,
+        targetLanguageCode = this[Keys.targetLanguage] ?: UserSettings.Defaults.TARGET_LANGUAGE,
+        fontSizeSp = this[Keys.fontSizeSp] ?: UserSettings.Defaults.FONT_SIZE_SP,
+        backgroundAlpha = this[Keys.backgroundAlpha] ?: UserSettings.Defaults.BACKGROUND_ALPHA,
+        bilingual = this[Keys.bilingual] ?: UserSettings.Defaults.BILINGUAL,
+        playTranslatedAudio = this[Keys.playTranslatedAudio]
+            ?: UserSettings.Defaults.PLAY_TRANSLATED_AUDIO,
+        translatedVolume = this[Keys.translatedVolume] ?: UserSettings.Defaults.TRANSLATED_VOLUME,
+        overlayX = this[Keys.overlayX] ?: UserSettings.Defaults.OVERLAY_X,
+        overlayY = this[Keys.overlayY] ?: UserSettings.Defaults.OVERLAY_Y,
+        overlayWidthDp = this[Keys.overlayWidthDp] ?: UserSettings.Defaults.OVERLAY_WIDTH_DP,
+        overlayHeightDp = this[Keys.overlayHeightDp] ?: UserSettings.Defaults.OVERLAY_HEIGHT_DP,
+        audioSourceMode = AudioSourceMode.fromStorage(this[Keys.audioSourceMode]),
+    )
 }

--- a/app/src/main/java/com/livetranslate/app/service/SessionBus.kt
+++ b/app/src/main/java/com/livetranslate/app/service/SessionBus.kt
@@ -24,6 +24,10 @@ object SessionBus {
         val message: String = "",
         val inputPreview: String = "",
         val outputPreview: String = "",
+        /** Full session transcripts retained after stop for MD export. */
+        val lastInputFull: String = "",
+        val lastOutputFull: String = "",
+        val canExport: Boolean = false,
     )
 
     private val _state = MutableStateFlow(UiState())
@@ -49,6 +53,22 @@ object SessionBus {
             inputPreview = input ?: _state.value.inputPreview,
             outputPreview = output ?: _state.value.outputPreview,
         )
+    }
+
+    fun markSessionFinished(inputFull: String, outputFull: String, message: String) {
+        _state.value = _state.value.copy(
+            status = Status.Stopped,
+            message = message,
+            inputPreview = outputFull.ifBlank { inputFull }.takeLast(200),
+            outputPreview = outputFull.takeLast(400),
+            lastInputFull = inputFull,
+            lastOutputFull = outputFull,
+            canExport = inputFull.isNotBlank() || outputFull.isNotBlank(),
+        )
+    }
+
+    fun clearExport() {
+        _state.value = _state.value.copy(canExport = false)
     }
 
     suspend fun stop() {

--- a/app/src/main/java/com/livetranslate/app/service/SubtitleSessionService.kt
+++ b/app/src/main/java/com/livetranslate/app/service/SubtitleSessionService.kt
@@ -15,8 +15,11 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.livetranslate.app.LiveTranslateApp
 import com.livetranslate.app.R
+import com.livetranslate.app.audio.MicAudioCapturer
+import com.livetranslate.app.audio.PcmMixer
 import com.livetranslate.app.audio.SystemAudioCapturer
 import com.livetranslate.app.audio.TranslatedAudioPlayer
+import com.livetranslate.app.data.AudioSourceMode
 import com.livetranslate.app.data.UserSettings
 import com.livetranslate.app.live.LiveTranslateClient
 import com.livetranslate.app.overlay.SubtitleOverlayController
@@ -29,16 +32,19 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 /**
- * Single foreground service: MediaProjection capture + Live WS + floating overlay.
+ * Foreground session: audio capture (media / mic / both) + Live WS + floating overlay.
  */
 class SubtitleSessionService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private var mediaProjection: MediaProjection? = null
-    private var capturer: SystemAudioCapturer? = null
+    private var mediaCapturer: SystemAudioCapturer? = null
+    private var micCapturer: MicAudioCapturer? = null
+    private var pcmMixer: PcmMixer? = null
     private var liveClient: LiveTranslateClient? = null
     private var audioPlayer: TranslatedAudioPlayer? = null
     private var overlay: SubtitleOverlayController? = null
@@ -47,8 +53,13 @@ class SubtitleSessionService : Service() {
     private var commandJob: Job? = null
 
     private var currentSettings: UserSettings = UserSettings()
+    private var audioSourceMode: AudioSourceMode = AudioSourceMode.MEDIA
+    private var captureStarted = false
+
     private var accumulatedInput = StringBuilder()
     private var accumulatedOutput = StringBuilder()
+    private var fullInput = StringBuilder()
+    private var fullOutput = StringBuilder()
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -70,6 +81,8 @@ class SubtitleSessionService : Service() {
                 return START_NOT_STICKY
             }
             ACTION_START -> {
+                val modeName = intent.getStringExtra(EXTRA_AUDIO_SOURCE)
+                audioSourceMode = AudioSourceMode.fromStorage(modeName)
                 val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED)
                 val data = if (Build.VERSION.SDK_INT >= 33) {
                     intent.getParcelableExtra(EXTRA_RESULT_DATA, Intent::class.java)
@@ -77,24 +90,33 @@ class SubtitleSessionService : Service() {
                     @Suppress("DEPRECATION")
                     intent.getParcelableExtra(EXTRA_RESULT_DATA)
                 }
-                if (data == null || resultCode != Activity.RESULT_OK) {
-                    SessionBus.setStatus(SessionBus.Status.Error, "录屏授权失败")
-                    stopSelf()
-                    return START_NOT_STICKY
+                if (audioSourceMode.needsMediaProjection) {
+                    if (data == null || resultCode != Activity.RESULT_OK) {
+                        SessionBus.setStatus(SessionBus.Status.Error, "录屏授权失败")
+                        stopSelf()
+                        return START_NOT_STICKY
+                    }
+                    startSession(resultCode, data)
+                } else {
+                    startSession(resultCode = null, data = null)
                 }
-                startSession(resultCode, data)
             }
         }
         return START_STICKY
     }
 
-    private fun startSession(resultCode: Int, data: Intent) {
+    private fun startSession(resultCode: Int?, data: Intent?) {
         SessionBus.setStatus(SessionBus.Status.Starting, "正在启动…")
+        SessionBus.clearExport()
+        accumulatedInput.clear()
+        accumulatedOutput.clear()
+        fullInput.clear()
+        fullOutput.clear()
+        captureStarted = false
         startAsForeground()
 
         val app = application as LiveTranslateApp
-        val apiKey = app.apiKeyStore.getApiKey()
-        if (apiKey.isBlank()) {
+        if (!app.apiKeyStore.hasApiKey()) {
             SessionBus.setStatus(SessionBus.Status.Error, "请先在设置中填写 API Key")
             stopSelf()
             return
@@ -102,24 +124,27 @@ class SubtitleSessionService : Service() {
 
         scope.launch {
             currentSettings = app.settingsRepository.settings.first()
-            val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-            val projection = mpm.getMediaProjection(resultCode, data)
-            if (projection == null) {
-                SessionBus.setStatus(SessionBus.Status.Error, "无法创建 MediaProjection")
-                stopSelf()
-                return@launch
-            }
-            mediaProjection = projection
-            projection.registerCallback(
-                object : MediaProjection.Callback() {
-                    override fun onStop() {
-                        stopEverything("录屏权限已撤销")
-                    }
-                },
-                null,
-            )
+            // audioSourceMode already set from Intent EXTRA in onStartCommand.
 
-            // Overlay
+            if (audioSourceMode.needsMediaProjection) {
+                val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+                val projection = mpm.getMediaProjection(resultCode!!, data!!)
+                if (projection == null) {
+                    SessionBus.setStatus(SessionBus.Status.Error, "无法创建 MediaProjection")
+                    stopSelf()
+                    return@launch
+                }
+                mediaProjection = projection
+                projection.registerCallback(
+                    object : MediaProjection.Callback() {
+                        override fun onStop() {
+                            stopEverything("录屏权限已撤销")
+                        }
+                    },
+                    null,
+                )
+            }
+
             val overlayController = SubtitleOverlayController(this@SubtitleSessionService) { x, y, w, h ->
                 ioScope.launch {
                     app.settingsRepository.update {
@@ -130,8 +155,6 @@ class SubtitleSessionService : Service() {
             overlay = overlayController
             overlayController.show(currentSettings)
 
-            // Live client — MUST subscribe to events BEFORE connect(), otherwise a fast
-            // setupComplete can be lost (SharedFlow replay=0) and capture never starts.
             val client = LiveTranslateClient()
             liveClient = client
 
@@ -141,15 +164,12 @@ class SubtitleSessionService : Service() {
             player.setVolume(currentSettings.translatedVolume)
 
             eventsJob = scope.launch {
-                // Also watch connectionState so we recover if SetupComplete event is missed.
                 launch {
                     client.connectionState.collect { state ->
                         when (state) {
                             is LiveTranslateClient.ConnectionState.Ready -> {
-                                if (capturer == null) {
-                                    SessionBus.setStatus(SessionBus.Status.Running, "翻译中")
-                                    startCapture(projection, client)
-                                }
+                                SessionBus.setStatus(SessionBus.Status.Running, "翻译中")
+                                startCapturePipeline(client)
                             }
                             is LiveTranslateClient.ConnectionState.Failed -> {
                                 SessionBus.setStatus(SessionBus.Status.Error, state.message)
@@ -162,16 +182,18 @@ class SubtitleSessionService : Service() {
                     when (event) {
                         is LiveTranslateClient.LiveEvent.SetupComplete -> {
                             SessionBus.setStatus(SessionBus.Status.Running, "翻译中")
-                            startCapture(projection, client)
+                            startCapturePipeline(client)
                         }
                         is LiveTranslateClient.LiveEvent.InputTranscript -> {
                             appendTranscript(accumulatedInput, event.text)
+                            appendFull(fullInput, event.text)
                             val text = accumulatedInput.toString()
                             overlay?.updateTranscripts(input = text, output = null)
                             SessionBus.setPreview(input = text)
                         }
                         is LiveTranslateClient.LiveEvent.OutputTranscript -> {
                             appendTranscript(accumulatedOutput, event.text)
+                            appendFull(fullOutput, event.text)
                             val text = accumulatedOutput.toString()
                             overlay?.updateTranscripts(input = null, output = text)
                             SessionBus.setPreview(output = text)
@@ -191,19 +213,6 @@ class SubtitleSessionService : Service() {
                 }
             }
 
-            // Yield so collectors are registered, then connect.
-            kotlinx.coroutines.yield()
-            client.connect(
-                LiveTranslateClient.SessionConfig(
-                    endpoint = currentSettings.endpoint,
-                    apiKey = apiKey,
-                    modelId = currentSettings.modelId,
-                    targetLanguageCode = currentSettings.targetLanguageCode,
-                    echoTargetLanguage = true,
-                ),
-            )
-
-            // React to settings changes (style / audio) while running
             settingsJob = scope.launch {
                 app.settingsRepository.settings.collectLatest { s ->
                     val prevPlay = currentSettings.playTranslatedAudio
@@ -211,46 +220,106 @@ class SubtitleSessionService : Service() {
                     overlay?.updateSettings(s)
                     player.setEnabled(s.playTranslatedAudio)
                     player.setVolume(s.translatedVolume)
-                    // Turning off mid-session: drop any backlog immediately
                     if (prevPlay && !s.playTranslatedAudio) {
-                        Log.i(TAG, "translated audio disabled — queue cleared by player")
+                        Log.i(TAG, "translated audio disabled")
                     }
                 }
             }
+
+            yield()
+            // Rotate keys: try first available via round-robin start index
+            val key = app.apiKeyStore.nextRotatedKey()
+            if (key.isBlank()) {
+                SessionBus.setStatus(SessionBus.Status.Error, "请先在设置中填写 API Key")
+                stopSelf()
+                return@launch
+            }
+            client.connect(
+                LiveTranslateClient.SessionConfig(
+                    endpoint = currentSettings.endpoint,
+                    apiKey = key,
+                    modelId = currentSettings.modelId,
+                    targetLanguageCode = currentSettings.targetLanguageCode,
+                    echoTargetLanguage = true,
+                ),
+            )
         }
     }
 
-    private fun startCapture(projection: MediaProjection, client: LiveTranslateClient) {
-        if (capturer != null) return
-        val cap = SystemAudioCapturer(ioScope)
-        capturer = cap
+    private fun startCapturePipeline(client: LiveTranslateClient) {
+        if (captureStarted) return
+        captureStarted = true
         try {
-            cap.start(projection) { pcm ->
-                client.sendPcm16le(pcm, 16_000)
+            when (audioSourceMode) {
+                AudioSourceMode.MEDIA -> {
+                    val projection = mediaProjection
+                        ?: throw IllegalStateException("缺少 MediaProjection")
+                    val cap = SystemAudioCapturer(ioScope)
+                    mediaCapturer = cap
+                    cap.start(projection) { pcm -> client.sendPcm16le(pcm, 16_000) }
+                }
+                AudioSourceMode.MIC -> {
+                    val mic = MicAudioCapturer(ioScope)
+                    micCapturer = mic
+                    mic.start { pcm -> client.sendPcm16le(pcm, 16_000) }
+                }
+                AudioSourceMode.MEDIA_AND_MIC -> {
+                    val projection = mediaProjection
+                        ?: throw IllegalStateException("缺少 MediaProjection")
+                    val mixer = PcmMixer { mixed -> client.sendPcm16le(mixed, 16_000) }
+                    pcmMixer = mixer
+                    val media = SystemAudioCapturer(ioScope)
+                    mediaCapturer = media
+                    media.start(projection) { pcm -> mixer.offerMedia(pcm) }
+                    val mic = MicAudioCapturer(ioScope)
+                    micCapturer = mic
+                    mic.start { pcm -> mixer.offerMic(pcm) }
+                }
             }
             SessionBus.setStatus(SessionBus.Status.Running, "翻译中 · 等待声音…")
         } catch (e: Exception) {
             Log.e(TAG, "capture start failed", e)
-            SessionBus.setStatus(SessionBus.Status.Error, e.message ?: "内录启动失败")
-            stopEverything(e.message ?: "内录启动失败")
+            SessionBus.setStatus(SessionBus.Status.Error, e.message ?: "音频采集启动失败")
+            stopEverything(e.message ?: "音频采集启动失败")
         }
     }
 
     private fun appendTranscript(buffer: StringBuilder, chunk: String) {
-        // Live transcripts are often cumulative or partial; keep last ~800 chars.
         if (chunk.length >= buffer.length && chunk.startsWith(buffer.toString())) {
             buffer.clear()
             buffer.append(chunk)
         } else if (buffer.endsWith(chunk)) {
-            // ignore duplicate
+            // ignore
         } else {
-            if (buffer.isNotEmpty() && !buffer.last().isWhitespace() && !chunk.first().isWhitespace()) {
+            if (buffer.isNotEmpty() && !buffer.last().isWhitespace() && chunk.isNotEmpty() &&
+                !chunk.first().isWhitespace()
+            ) {
                 buffer.append(' ')
             }
             buffer.append(chunk)
         }
         if (buffer.length > 800) {
             buffer.delete(0, buffer.length - 800)
+        }
+    }
+
+    private fun appendFull(buffer: StringBuilder, chunk: String) {
+        // Prefer cumulative server rewrites when present
+        if (chunk.length >= buffer.length && buffer.isNotEmpty() && chunk.startsWith(buffer.toString())) {
+            buffer.clear()
+            buffer.append(chunk)
+            return
+        }
+        if (buffer.endsWith(chunk)) return
+        if (buffer.isNotEmpty() && !buffer.last().isWhitespace() && chunk.isNotEmpty() &&
+            !chunk.first().isWhitespace()
+        ) {
+            buffer.append(' ')
+        }
+        buffer.append(chunk)
+        // Cap export size ~200k chars
+        if (buffer.length > 200_000) {
+            buffer.delete(0, buffer.length - 200_000)
         }
     }
 
@@ -271,27 +340,47 @@ class SubtitleSessionService : Service() {
         val notification: Notification = NotificationCompat.Builder(this, LiveTranslateApp.CHANNEL_SUBTITLE)
             .setContentTitle(getString(R.string.notification_subtitle_running))
             .setContentText(getString(R.string.notification_subtitle_text))
-            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setSmallIcon(R.mipmap.ic_launcher)
             .setContentIntent(openPi)
             .addAction(0, getString(R.string.action_stop), stopPi)
             .setOngoing(true)
             .build()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION,
-            )
+        val fgsType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            when (audioSourceMode) {
+                AudioSourceMode.MEDIA ->
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+                AudioSourceMode.MIC ->
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                AudioSourceMode.MEDIA_AND_MIC ->
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            }
+        } else {
+            0
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && fgsType != 0) {
+            startForeground(NOTIFICATION_ID, notification, fgsType)
         } else {
             startForeground(NOTIFICATION_ID, notification)
         }
     }
 
     private fun stopEverything(message: String) {
-        SessionBus.setStatus(SessionBus.Status.Stopped, message)
-        capturer?.stop()
-        capturer = null
+        val inFull = fullInput.toString()
+        val outFull = fullOutput.toString()
+        if (inFull.isNotBlank() || outFull.isNotBlank()) {
+            SessionBus.markSessionFinished(inFull, outFull, message)
+        } else {
+            SessionBus.setStatus(SessionBus.Status.Stopped, message)
+        }
+        mediaCapturer?.stop()
+        mediaCapturer = null
+        micCapturer?.stop()
+        micCapturer = null
+        pcmMixer?.close()
+        pcmMixer = null
         liveClient?.close()
         liveClient?.destroy()
         liveClient = null
@@ -299,20 +388,29 @@ class SubtitleSessionService : Service() {
         audioPlayer = null
         overlay?.hide()
         overlay = null
-        mediaProjection?.stop()
+        try {
+            mediaProjection?.stop()
+        } catch (_: Exception) {
+        }
         mediaProjection = null
         settingsJob?.cancel()
         eventsJob?.cancel()
+        captureStarted = false
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 
     override fun onDestroy() {
-        capturer?.stop()
+        mediaCapturer?.stop()
+        micCapturer?.stop()
+        pcmMixer?.close()
         liveClient?.destroy()
         audioPlayer?.release()
         overlay?.hide()
-        mediaProjection?.stop()
+        try {
+            mediaProjection?.stop()
+        } catch (_: Exception) {
+        }
         scope.cancel()
         ioScope.cancel()
         super.onDestroy()
@@ -325,12 +423,21 @@ class SubtitleSessionService : Service() {
         const val ACTION_STOP = "com.livetranslate.app.action.STOP_SUBTITLE"
         const val EXTRA_RESULT_CODE = "result_code"
         const val EXTRA_RESULT_DATA = "result_data"
+        const val EXTRA_AUDIO_SOURCE = "audio_source"
 
-        fun start(context: Context, resultCode: Int, data: Intent) {
+        fun start(
+            context: Context,
+            audioSource: AudioSourceMode,
+            resultCode: Int? = null,
+            data: Intent? = null,
+        ) {
             val intent = Intent(context, SubtitleSessionService::class.java).apply {
                 action = ACTION_START
-                putExtra(EXTRA_RESULT_CODE, resultCode)
-                putExtra(EXTRA_RESULT_DATA, data)
+                putExtra(EXTRA_AUDIO_SOURCE, audioSource.name)
+                if (resultCode != null && data != null) {
+                    putExtra(EXTRA_RESULT_CODE, resultCode)
+                    putExtra(EXTRA_RESULT_DATA, data)
+                }
             }
             context.startForegroundService(intent)
         }

--- a/app/src/main/java/com/livetranslate/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/main/MainActivity.kt
@@ -2,6 +2,7 @@ package com.livetranslate.app.ui.main
 
 import android.Manifest
 import android.app.Activity
+import android.app.Application
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.projection.MediaProjectionManager
@@ -36,6 +37,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.livetranslate.app.LiveTranslateApp
 import com.livetranslate.app.R
+import com.livetranslate.app.data.AudioSourceMode
 import com.livetranslate.app.service.SessionBus
 import com.livetranslate.app.service.SubtitleSessionService
 import com.livetranslate.app.ui.settings.SettingsScreen
@@ -65,7 +67,11 @@ class MainActivity : ComponentActivity() {
                 var tab by remember { mutableIntStateOf(0) }
 
                 val subtitleVm: SubtitleViewModel = viewModel(
-                    factory = SubtitleViewModelFactory(app.settingsRepository, app.apiKeyStore),
+                    factory = SubtitleViewModelFactory(
+                        application as Application,
+                        app.settingsRepository,
+                        app.apiKeyStore,
+                    ),
                 )
                 val settingsVm: SettingsViewModel = viewModel(
                     factory = SettingsViewModelFactory(app.settingsRepository, app.apiKeyStore),
@@ -73,6 +79,7 @@ class MainActivity : ComponentActivity() {
 
                 val session by SessionBus.state.collectAsStateWithLifecycle()
                 val settings by subtitleVm.settings.collectAsStateWithLifecycle()
+                val exportMessage by subtitleVm.exportMessage.collectAsStateWithLifecycle()
 
                 var pendingStart by remember { mutableStateOf(false) }
 
@@ -81,7 +88,12 @@ class MainActivity : ComponentActivity() {
                 ) { result ->
                     if (result.resultCode == Activity.RESULT_OK && result.data != null) {
                         runCatching {
-                            SubtitleSessionService.start(this, result.resultCode, result.data!!)
+                            SubtitleSessionService.start(
+                                this,
+                                audioSource = settings.audioSourceMode,
+                                resultCode = result.resultCode,
+                                data = result.data!!,
+                            )
                         }.onFailure {
                             Log.e(TAG, "start service failed", it)
                             SessionBus.setStatus(
@@ -102,7 +114,7 @@ class MainActivity : ComponentActivity() {
                 ) {
                     if (PermissionUtils.canDrawOverlays(this) && pendingStart) {
                         pendingStart = false
-                        launchProjection(projectionLauncher::launch)
+                        continueStartAfterPermissions(settings.audioSourceMode, projectionLauncher::launch)
                     }
                 }
 
@@ -121,7 +133,7 @@ class MainActivity : ComponentActivity() {
                         pendingStart = true
                         overlayLauncher.launch(PermissionUtils.overlaySettingsIntent(this))
                     } else {
-                        launchProjection(projectionLauncher::launch)
+                        continueStartAfterPermissions(settings.audioSourceMode, projectionLauncher::launch)
                     }
                 }
 
@@ -135,12 +147,19 @@ class MainActivity : ComponentActivity() {
                             tab = 1
                             return
                         }
+                        val mode = settings.audioSourceMode
                         val needed = buildList {
-                            add(Manifest.permission.RECORD_AUDIO)
+                            if (mode.needsMicrophone) {
+                                add(Manifest.permission.RECORD_AUDIO)
+                            }
+                            // Media capture also uses AudioRecord path that may need RECORD_AUDIO on some OEMs
+                            if (mode.needsMediaProjection) {
+                                add(Manifest.permission.RECORD_AUDIO)
+                            }
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                                 add(Manifest.permission.POST_NOTIFICATIONS)
                             }
-                        }.filter {
+                        }.distinct().filter {
                             ContextCompat.checkSelfPermission(this, it) !=
                                 PackageManager.PERMISSION_GRANTED
                         }
@@ -153,7 +172,7 @@ class MainActivity : ComponentActivity() {
                             overlayLauncher.launch(PermissionUtils.overlaySettingsIntent(this))
                             return
                         }
-                        launchProjection(projectionLauncher::launch)
+                        continueStartAfterPermissions(mode, projectionLauncher::launch)
                     } catch (t: Throwable) {
                         Log.e(TAG, "requestStartSubtitle", t)
                         SessionBus.setStatus(
@@ -165,7 +184,6 @@ class MainActivity : ComponentActivity() {
 
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),
-                    // MIUIX: page background is surface (#F7F7F7 gray); cards use surfaceContainer white
                     containerColor = MiuixTheme.colorScheme.surface,
                     bottomBar = {
                         NavigationBar(mode = NavigationBarDisplayMode.IconAndText) {
@@ -184,7 +202,6 @@ class MainActivity : ComponentActivity() {
                         }
                     },
                 ) { padding ->
-                    // Compose AnimatedContent — MIUIX has no dedicated tab page transition.
                     AnimatedContent(
                         targetState = tab,
                         modifier = Modifier
@@ -208,11 +225,15 @@ class MainActivity : ComponentActivity() {
                                 modifier = Modifier.fillMaxSize(),
                                 settings = settings,
                                 session = session,
+                                exportMessage = exportMessage,
                                 onSourceLanguage = { code ->
                                     scope.launch { subtitleVm.setSourceLanguage(code) }
                                 },
                                 onTargetLanguage = { code ->
                                     scope.launch { subtitleVm.setTargetLanguage(code) }
+                                },
+                                onAudioSource = { mode ->
+                                    scope.launch { subtitleVm.setAudioSource(mode) }
                                 },
                                 onStart = { requestStartSubtitle() },
                                 onStop = {
@@ -223,7 +244,7 @@ class MainActivity : ComponentActivity() {
                                         }
                                     }
                                 },
-                                onOpenSettings = { tab = 1 },
+                                onExport = { subtitleVm.exportLastSession() },
                                 canDrawOverlays = PermissionUtils.canDrawOverlays(this@MainActivity),
                             )
                             else -> SettingsScreen(
@@ -242,13 +263,27 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun launchProjection(launch: (Intent) -> Unit) {
-        SessionBus.setStatus(
-            SessionBus.Status.Starting,
-            getString(R.string.msg_requesting_projection),
-        )
-        val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-        launch(mpm.createScreenCaptureIntent())
+    private fun continueStartAfterPermissions(
+        mode: AudioSourceMode,
+        launchProjection: (Intent) -> Unit,
+    ) {
+        if (mode.needsMediaProjection) {
+            SessionBus.setStatus(
+                SessionBus.Status.Starting,
+                getString(R.string.msg_requesting_projection),
+            )
+            val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+            launchProjection(mpm.createScreenCaptureIntent())
+        } else {
+            runCatching {
+                SubtitleSessionService.start(this, audioSource = mode)
+            }.onFailure {
+                SessionBus.setStatus(
+                    SessionBus.Status.Error,
+                    getString(R.string.msg_service_start_failed, it.message.orEmpty()),
+                )
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/livetranslate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/settings/SettingsScreen.kt
@@ -252,13 +252,16 @@ fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                 )
                 if (!testResult.isNullOrBlank()) {
+                    val resultText = testResult.orEmpty()
+                    val hasOk = resultText.contains("✅")
+                    val hasFail = resultText.contains("❌")
                     Text(
-                        text = testResult.orEmpty(),
+                        text = resultText,
                         fontSize = 13.sp,
                         color = when {
-                            testResult!!.startsWith("✅") -> Booth.Success
-                            testResult!!.startsWith("❌") -> Booth.Danger
-                            else -> MiuixTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                            hasOk && !hasFail -> Booth.Success
+                            hasFail && !hasOk -> Booth.Danger
+                            else -> MiuixTheme.colorScheme.onSurface.copy(alpha = 0.85f)
                         },
                     )
                 }

--- a/app/src/main/java/com/livetranslate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/settings/SettingsScreen.kt
@@ -4,15 +4,23 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Remove
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -21,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -35,6 +44,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.livetranslate.app.BuildConfig
 import com.livetranslate.app.R
+import com.livetranslate.app.data.ApiKeyStore
 import com.livetranslate.app.ui.components.PageTitle
 import com.livetranslate.app.ui.components.SectionCard
 import com.livetranslate.app.ui.components.SettingSwitchRow
@@ -54,7 +64,7 @@ fun SettingsScreen(
     onOpenOverlayPermission: () -> Unit,
 ) {
     val settings by viewModel.settings.collectAsStateWithLifecycle()
-    val apiKeyFromVm by viewModel.apiKeyDraft.collectAsStateWithLifecycle()
+    val apiKeyFields by viewModel.apiKeyFields.collectAsStateWithLifecycle()
     val testResult by viewModel.testResult.collectAsStateWithLifecycle()
     val testing by viewModel.testing.collectAsStateWithLifecycle()
 
@@ -63,9 +73,6 @@ fun SettingsScreen(
     }
     var modelField by remember {
         mutableStateOf(TextFieldValue(settings.modelId, TextRange(settings.modelId.length)))
-    }
-    var apiKeyField by remember {
-        mutableStateOf(TextFieldValue(apiKeyFromVm, TextRange(apiKeyFromVm.length)))
     }
     var revealKey by remember { mutableStateOf(false) }
 
@@ -83,20 +90,22 @@ fun SettingsScreen(
             modelHydrated = true
         }
     }
-    LaunchedEffect(apiKeyFromVm) {
-        if (apiKeyField.text.isEmpty() && apiKeyFromVm.isNotEmpty()) {
-            apiKeyField = TextFieldValue(apiKeyFromVm, TextRange(apiKeyFromVm.length))
-        }
-    }
 
-    // Fields sit on white cards — soft gray fill like MIUI preference inputs
+    // Dark-mode safe field colors (explicit text / cursor colors)
+    val scheme = MiuixTheme.colorScheme
     val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = scheme.onSurface,
+        unfocusedTextColor = scheme.onSurface,
+        disabledTextColor = scheme.disabledOnSurface,
         focusedBorderColor = Booth.Accent,
-        unfocusedBorderColor = MiuixTheme.colorScheme.outline.copy(alpha = 0.35f),
+        unfocusedBorderColor = scheme.outline.copy(alpha = 0.45f),
         focusedLabelColor = Booth.Accent,
+        unfocusedLabelColor = scheme.onSurfaceVariantSummary,
         cursorColor = Booth.Accent,
-        focusedContainerColor = MiuixTheme.colorScheme.surface,
-        unfocusedContainerColor = MiuixTheme.colorScheme.surface,
+        focusedContainerColor = scheme.surface,
+        unfocusedContainerColor = scheme.surface,
+        focusedPlaceholderColor = scheme.onSurfaceVariantSummary,
+        unfocusedPlaceholderColor = scheme.onSurfaceVariantSummary,
     )
 
     Column(
@@ -137,32 +146,78 @@ fun SettingsScreen(
                     shape = RoundedCornerShape(16.dp),
                     colors = fieldColors,
                 )
-                OutlinedTextField(
-                    value = apiKeyField,
-                    onValueChange = { v ->
-                        apiKeyField = v
-                        viewModel.setApiKeyDraft(v.text)
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { androidx.compose.material3.Text(stringResource(R.string.settings_api_key)) },
-                    singleLine = true,
-                    visualTransformation = if (revealKey) {
-                        VisualTransformation.None
-                    } else {
-                        PasswordVisualTransformation()
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-                    trailingIcon = {
-                        TextButton(
-                            text = stringResource(
-                                if (revealKey) R.string.settings_hide else R.string.settings_show,
-                            ),
-                            onClick = { revealKey = !revealKey },
-                        )
-                    },
-                    shape = RoundedCornerShape(16.dp),
-                    colors = fieldColors,
+
+                Text(
+                    text = stringResource(R.string.settings_api_keys_hint),
+                    fontSize = 12.sp,
+                    color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
                 )
+
+                apiKeyFields.forEachIndexed { index, field ->
+                    val isLast = index == apiKeyFields.lastIndex
+                    val canAdd = isLast && apiKeyFields.size < ApiKeyStore.MAX_KEYS
+                    val canRemove = index > 0
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (canAdd) {
+                            IconButton(
+                                onClick = viewModel::addApiKeyField,
+                                modifier = Modifier.size(40.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Add,
+                                    contentDescription = stringResource(R.string.settings_add_key),
+                                    tint = Booth.Accent,
+                                )
+                            }
+                        } else {
+                            Spacer(modifier = Modifier.width(40.dp))
+                        }
+                        OutlinedTextField(
+                            value = field,
+                            onValueChange = { v -> viewModel.updateApiKeyField(index, v) },
+                            modifier = Modifier.weight(1f),
+                            label = {
+                                androidx.compose.material3.Text(
+                                    stringResource(R.string.settings_api_key_n, index + 1),
+                                )
+                            },
+                            singleLine = true,
+                            visualTransformation = if (revealKey) {
+                                VisualTransformation.None
+                            } else {
+                                PasswordVisualTransformation()
+                            },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                            shape = RoundedCornerShape(16.dp),
+                            colors = fieldColors,
+                        )
+                        if (canRemove) {
+                            IconButton(
+                                onClick = { viewModel.removeApiKeyField(index) },
+                                modifier = Modifier.size(40.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Remove,
+                                    contentDescription = stringResource(R.string.settings_remove_key),
+                                    tint = Booth.Danger,
+                                )
+                            }
+                        } else {
+                            Spacer(modifier = Modifier.width(40.dp))
+                        }
+                    }
+                }
+
+                TextButton(
+                    text = stringResource(
+                        if (revealKey) R.string.settings_hide else R.string.settings_show,
+                    ),
+                    onClick = { revealKey = !revealKey },
+                )
+
                 OutlinedTextField(
                     value = modelField,
                     onValueChange = { v ->
@@ -177,7 +232,7 @@ fun SettingsScreen(
                 )
                 Button(
                     onClick = {
-                        viewModel.saveApiKey()
+                        viewModel.saveApiKeys()
                         viewModel.testConnection()
                     },
                     enabled = !testing,
@@ -193,7 +248,7 @@ fun SettingsScreen(
                 }
                 TextButton(
                     text = stringResource(R.string.settings_save_key_only),
-                    onClick = viewModel::saveApiKey,
+                    onClick = viewModel::saveApiKeys,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 if (!testResult.isNullOrBlank()) {

--- a/app/src/main/java/com/livetranslate/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/settings/SettingsViewModel.kt
@@ -90,12 +90,15 @@ class SettingsViewModel(
 
             val endpoint = s.endpoint.trim().ifBlank { UserSettings.Defaults.ENDPOINT }
             val modelId = s.modelId.trim().ifBlank { UserSettings.Defaults.MODEL_ID }
+            val targetLang = s.targetLanguageCode.ifBlank { "zh-Hans" }
 
-            var lastError: String? = null
-            var success: String? = null
+            val lines = mutableListOf<String>()
+            var okCount = 0
             for ((i, key) in keys.withIndex()) {
+                val n = i + 1
+                _testResult.value = "测试中… Key $n / ${keys.size}"
                 if (key.length < 16) {
-                    lastError = "Key ${i + 1} 太短"
+                    lines += "❌ Key $n：太短"
                     continue
                 }
                 val client = LiveTranslateClient()
@@ -104,22 +107,26 @@ class SettingsViewModel(
                         endpoint = endpoint,
                         apiKey = key,
                         modelId = modelId,
-                        targetLanguageCode = s.targetLanguageCode.ifBlank { "zh-Hans" },
+                        targetLanguageCode = targetLang,
                     ),
                 )
                 client.destroy()
                 if (result.isSuccess) {
-                    success = "✅ Key ${i + 1} 可用：${result.getOrNull()}"
-                    break
+                    okCount++
+                    lines += "✅ Key $n 可用：${result.getOrNull()}"
+                } else {
+                    lines += "❌ Key $n：${result.exceptionOrNull()?.message.orEmpty()}"
                 }
-                lastError = "Key ${i + 1}：${result.exceptionOrNull()?.message}"
             }
 
-            _testResult.value = success ?: buildString {
-                append("❌ 失败：")
-                append(lastError.orEmpty())
+            _testResult.value = buildString {
+                append(lines.joinToString("\n"))
                 append('\n')
-                append("提示：请检查网络、端点、模型 ID 与 API Key。")
+                when {
+                    okCount == keys.size -> append("全部 ${keys.size} 个 Key 可用")
+                    okCount > 0 -> append("$okCount / ${keys.size} 个 Key 可用")
+                    else -> append("提示：请检查网络、端点、模型 ID 与 API Key。")
+                }
             }
             _testing.value = false
         }

--- a/app/src/main/java/com/livetranslate/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/settings/SettingsViewModel.kt
@@ -1,5 +1,7 @@
 package com.livetranslate.app.ui.settings
 
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -21,8 +23,11 @@ class SettingsViewModel(
     val settings: StateFlow<UserSettings> = settingsRepository.settings
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UserSettings())
 
-    private val _apiKeyDraft = MutableStateFlow(apiKeyStore.getApiKey())
-    val apiKeyDraft: StateFlow<String> = _apiKeyDraft.asStateFlow()
+    private val initialKeys = apiKeyStore.getApiKeys().ifEmpty { listOf("") }
+    private val _apiKeyFields = MutableStateFlow(
+        initialKeys.map { TextFieldValue(it, TextRange(it.length)) },
+    )
+    val apiKeyFields: StateFlow<List<TextFieldValue>> = _apiKeyFields.asStateFlow()
 
     private val _testResult = MutableStateFlow<String?>(null)
     val testResult: StateFlow<String?> = _testResult.asStateFlow()
@@ -30,12 +35,34 @@ class SettingsViewModel(
     private val _testing = MutableStateFlow(false)
     val testing: StateFlow<Boolean> = _testing.asStateFlow()
 
-    fun setApiKeyDraft(value: String) {
-        _apiKeyDraft.value = value
+    fun updateApiKeyField(index: Int, value: TextFieldValue) {
+        val list = _apiKeyFields.value.toMutableList()
+        if (index in list.indices) {
+            list[index] = value
+            _apiKeyFields.value = list
+        }
     }
 
-    fun saveApiKey() {
-        apiKeyStore.setApiKey(_apiKeyDraft.value)
+    fun addApiKeyField() {
+        val list = _apiKeyFields.value
+        if (list.size >= ApiKeyStore.MAX_KEYS) return
+        _apiKeyFields.value = list + TextFieldValue("")
+    }
+
+    fun removeApiKeyField(index: Int) {
+        val list = _apiKeyFields.value.toMutableList()
+        if (list.size <= 1) return
+        if (index in 1 until list.size) {
+            list.removeAt(index)
+            _apiKeyFields.value = list
+        }
+    }
+
+    fun saveApiKeys() {
+        val keys = _apiKeyFields.value.map { it.text.trim() }.filter { it.isNotEmpty() }
+        apiKeyStore.setApiKeys(keys)
+        val next = keys.ifEmpty { listOf("") }.map { TextFieldValue(it, TextRange(it.length)) }
+        _apiKeyFields.value = next
         _testResult.value = "✅"
     }
 
@@ -52,61 +79,48 @@ class SettingsViewModel(
             _testing.value = true
             _testResult.value = "测试中…"
             val s = settings.value
-            val key = _apiKeyDraft.value.ifBlank { apiKeyStore.getApiKey() }.trim()
-            if (key.isBlank()) {
+            // Persist drafts first
+            val keys = _apiKeyFields.value.map { it.text.trim() }.filter { it.isNotEmpty() }
+            if (keys.isEmpty()) {
                 _testResult.value = "失败：API Key 为空"
                 _testing.value = false
                 return@launch
             }
-            if (key.length < 16) {
-                _testResult.value = "失败：API Key 太短，请检查是否粘贴完整"
-                _testing.value = false
-                return@launch
-            }
-            // Persist draft key before test
-            apiKeyStore.setApiKey(key)
+            apiKeyStore.setApiKeys(keys)
+
             val endpoint = s.endpoint.trim().ifBlank { UserSettings.Defaults.ENDPOINT }
             val modelId = s.modelId.trim().ifBlank { UserSettings.Defaults.MODEL_ID }
-            val client = LiveTranslateClient()
-            val result = runCatching {
-                client.testConnection(
+
+            var lastError: String? = null
+            var success: String? = null
+            for ((i, key) in keys.withIndex()) {
+                if (key.length < 16) {
+                    lastError = "Key ${i + 1} 太短"
+                    continue
+                }
+                val client = LiveTranslateClient()
+                val result = client.testConnection(
                     LiveTranslateClient.SessionConfig(
                         endpoint = endpoint,
                         apiKey = key,
                         modelId = modelId,
                         targetLanguageCode = s.targetLanguageCode.ifBlank { "zh-Hans" },
                     ),
-                ).getOrElse { throw it }
+                )
+                client.destroy()
+                if (result.isSuccess) {
+                    success = "✅ Key ${i + 1} 可用：${result.getOrNull()}"
+                    break
+                }
+                lastError = "Key ${i + 1}：${result.exceptionOrNull()?.message}"
             }
-            _testResult.value = result.fold(
-                onSuccess = { "✅ $it\n端点/模型已验证" },
-                onFailure = { e ->
-                    val msg = e.message.orEmpty()
-                    buildString {
-                        append("❌ 失败：")
-                        append(msg.ifBlank { e.javaClass.simpleName })
-                        append('\n')
-                        when {
-                            msg.contains("Unable to resolve host", ignoreCase = true) ||
-                                msg.contains("Failed to connect", ignoreCase = true) ||
-                                msg.contains("timeout", ignoreCase = true) ||
-                                msg.contains("Connecting", ignoreCase = true) ->
-                                append("提示：网络连接失败，请检查网络后重试。")
-                            msg.contains("API_KEY", ignoreCase = true) ||
-                                msg.contains("401") ||
-                                msg.contains("403") ||
-                                msg.contains("PERMISSION", ignoreCase = true) ->
-                                append("提示：Key 无效、被禁用，或未开通 Generative Language API。")
-                            msg.contains("not found", ignoreCase = true) ||
-                                msg.contains("404") ->
-                                append("提示：模型 ID 可能不对，确认是 gemini-3.5-live-translate-preview")
-                            else ->
-                                append("提示：请检查端点、模型 ID 与 API Key。")
-                        }
-                    }
-                },
-            )
-            client.destroy()
+
+            _testResult.value = success ?: buildString {
+                append("❌ 失败：")
+                append(lastError.orEmpty())
+                append('\n')
+                append("提示：请检查网络、端点、模型 ID 与 API Key。")
+            }
             _testing.value = false
         }
     }

--- a/app/src/main/java/com/livetranslate/app/ui/subtitle/SubtitleScreen.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/subtitle/SubtitleScreen.kt
@@ -3,7 +3,6 @@ package com.livetranslate.app.ui.subtitle
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,6 +33,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.livetranslate.app.R
+import com.livetranslate.app.data.AudioSourceMode
 import com.livetranslate.app.data.LanguageOption
 import com.livetranslate.app.data.SupportedLanguages
 import com.livetranslate.app.data.UserSettings
@@ -47,7 +47,6 @@ import top.yukonga.miuix.kmp.basic.Button
 import top.yukonga.miuix.kmp.basic.ButtonDefaults
 import top.yukonga.miuix.kmp.basic.SmallTitle
 import top.yukonga.miuix.kmp.basic.Text
-import top.yukonga.miuix.kmp.basic.TextButton
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 private enum class LangPicker { Source, Target }
@@ -58,11 +57,13 @@ fun SubtitleScreen(
     modifier: Modifier = Modifier,
     settings: UserSettings,
     session: SessionBus.UiState,
+    exportMessage: String?,
     onSourceLanguage: (String) -> Unit,
     onTargetLanguage: (String) -> Unit,
+    onAudioSource: (AudioSourceMode) -> Unit,
     onStart: () -> Unit,
     onStop: () -> Unit,
-    onOpenSettings: () -> Unit,
+    onExport: () -> Unit,
     canDrawOverlays: Boolean,
 ) {
     val running = session.status == SessionBus.Status.Running ||
@@ -90,7 +91,6 @@ fun SubtitleScreen(
             subtitle = stringResource(R.string.subtitle_subtitle),
         )
 
-        // Primary control group — white card on gray page (MIUI style)
         SectionCard {
             Column(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
@@ -197,6 +197,33 @@ fun SubtitleScreen(
             }
         }
 
+        SmallTitle(
+            text = stringResource(R.string.subtitle_audio_source),
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
+        SectionCard {
+            Column(modifier = Modifier.padding(vertical = 6.dp)) {
+                AudioSourceRow(
+                    label = stringResource(R.string.audio_source_media),
+                    selected = settings.audioSourceMode == AudioSourceMode.MEDIA,
+                    enabled = !running,
+                    onClick = { onAudioSource(AudioSourceMode.MEDIA) },
+                )
+                AudioSourceRow(
+                    label = stringResource(R.string.audio_source_mic),
+                    selected = settings.audioSourceMode == AudioSourceMode.MIC,
+                    enabled = !running,
+                    onClick = { onAudioSource(AudioSourceMode.MIC) },
+                )
+                AudioSourceRow(
+                    label = stringResource(R.string.audio_source_both),
+                    selected = settings.audioSourceMode == AudioSourceMode.MEDIA_AND_MIC,
+                    enabled = !running,
+                    onClick = { onAudioSource(AudioSourceMode.MEDIA_AND_MIC) },
+                )
+            }
+        }
+
         if (session.outputPreview.isNotBlank() || session.inputPreview.isNotBlank()) {
             SmallTitle(
                 text = stringResource(R.string.subtitle_preview),
@@ -229,13 +256,32 @@ fun SubtitleScreen(
             }
         }
 
-        TextButton(
-            text = stringResource(R.string.subtitle_open_settings),
-            onClick = onOpenSettings,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp),
-        )
+        if (session.canExport && !running) {
+            SectionCard {
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Button(
+                        onClick = onExport,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColorsPrimary(),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.subtitle_export_md),
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    if (!exportMessage.isNullOrBlank()) {
+                        Text(
+                            text = exportMessage,
+                            fontSize = 13.sp,
+                            color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                        )
+                    }
+                }
+            }
+        }
 
         Spacer(modifier = Modifier.height(24.dp))
     }
@@ -306,6 +352,36 @@ fun SubtitleScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AudioSourceRow(
+    label: String,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.weight(1f),
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            color = when {
+                !enabled -> MiuixTheme.colorScheme.disabledOnSurface
+                selected -> Booth.Accent
+                else -> MiuixTheme.colorScheme.onSurface
+            },
+        )
+        if (selected) {
+            Text(text = "✓", color = Booth.Accent, fontWeight = FontWeight.Bold)
         }
     }
 }

--- a/app/src/main/java/com/livetranslate/app/ui/subtitle/SubtitleViewModel.kt
+++ b/app/src/main/java/com/livetranslate/app/ui/subtitle/SubtitleViewModel.kt
@@ -1,21 +1,35 @@
 package com.livetranslate.app.ui.subtitle
 
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.livetranslate.app.R
 import com.livetranslate.app.data.ApiKeyStore
+import com.livetranslate.app.data.AudioSourceMode
 import com.livetranslate.app.data.UserSettings
 import com.livetranslate.app.data.UserSettingsRepository
+import com.livetranslate.app.service.SessionBus
+import com.livetranslate.app.util.ExportTranslator
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 
 class SubtitleViewModel(
+    app: Application,
     private val settingsRepository: UserSettingsRepository,
     private val apiKeyStore: ApiKeyStore,
-) : ViewModel() {
+) : AndroidViewModel(app) {
     val settings: StateFlow<UserSettings> = settingsRepository.settings
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UserSettings())
+
+    private val _exportMessage = MutableStateFlow<String?>(null)
+    val exportMessage: StateFlow<String?> = _exportMessage.asStateFlow()
 
     fun hasApiKey(): Boolean = apiKeyStore.hasApiKey()
 
@@ -26,14 +40,46 @@ class SubtitleViewModel(
     suspend fun setTargetLanguage(code: String) {
         settingsRepository.update { it.copy(targetLanguageCode = code) }
     }
+
+    suspend fun setAudioSource(mode: AudioSourceMode) {
+        settingsRepository.update { it.copy(audioSourceMode = mode) }
+    }
+
+    fun exportLastSession() {
+        val s = SessionBus.state.value
+        if (!s.canExport) {
+            _exportMessage.value = getApplication<Application>().getString(R.string.subtitle_export_empty)
+            return
+        }
+        val now = LocalDateTime.now()
+        val name = ExportTranslator.fileName(now)
+        val md = ExportTranslator.buildMarkdown(s.lastInputFull, s.lastOutputFull, now)
+        val result = ExportTranslator.saveToDownloads(getApplication(), name, md)
+        _exportMessage.value = result.fold(
+            onSuccess = { path ->
+                getApplication<Application>().getString(R.string.subtitle_export_ok, path)
+            },
+            onFailure = { e ->
+                getApplication<Application>().getString(
+                    R.string.subtitle_export_fail,
+                    e.message.orEmpty(),
+                )
+            },
+        )
+    }
+
+    fun clearExportMessage() {
+        _exportMessage.value = null
+    }
 }
 
 class SubtitleViewModelFactory(
+    private val app: Application,
     private val settingsRepository: UserSettingsRepository,
     private val apiKeyStore: ApiKeyStore,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return SubtitleViewModel(settingsRepository, apiKeyStore) as T
+        return SubtitleViewModel(app, settingsRepository, apiKeyStore) as T
     }
 }

--- a/app/src/main/java/com/livetranslate/app/util/ExportTranslator.kt
+++ b/app/src/main/java/com/livetranslate/app/util/ExportTranslator.kt
@@ -1,0 +1,83 @@
+package com.livetranslate.app.util
+
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import java.io.File
+import java.io.FileOutputStream
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object ExportTranslator {
+    /**
+     * Export session as Markdown.
+     *
+     * Format (two sections): full source block, then full translation block.
+     * Continuous Live transcripts are not reliably sentence-aligned, so pairing
+     * line-by-line would invent structure. Two sections stay faithful to the stream.
+     */
+    fun buildMarkdown(
+        sourceText: String,
+        translationText: String,
+        stoppedAt: LocalDateTime = LocalDateTime.now(),
+    ): String {
+        val timeLabel = stoppedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+        return buildString {
+            appendLine("# 翻译结果")
+            appendLine()
+            appendLine("- 停止时间：`$timeLabel`")
+            appendLine()
+            appendLine("## 原文")
+            appendLine()
+            appendLine(sourceText.ifBlank { "（无）" }.trim())
+            appendLine()
+            appendLine("## 译文")
+            appendLine()
+            appendLine(translationText.ifBlank { "（无）" }.trim())
+            appendLine()
+        }
+    }
+
+    /** e.g. 7月14日-22:35-翻译结果.md */
+    fun fileName(stoppedAt: LocalDateTime = LocalDateTime.now()): String {
+        val month = stoppedAt.monthValue
+        val day = stoppedAt.dayOfMonth
+        val hm = stoppedAt.format(DateTimeFormatter.ofPattern("HH:mm"))
+        return "${month}月${day}日-$hm-翻译结果.md"
+    }
+
+    /**
+     * Write to public Downloads. Returns display path or content URI string.
+     */
+    fun saveToDownloads(context: Context, fileName: String, content: String): Result<String> {
+        return runCatching {
+            val bytes = content.toByteArray(Charsets.UTF_8)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val values = ContentValues().apply {
+                    put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+                    put(MediaStore.MediaColumns.MIME_TYPE, "text/markdown")
+                    put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+                    put(MediaStore.MediaColumns.IS_PENDING, 1)
+                }
+                val resolver = context.contentResolver
+                val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                    ?: error("无法创建下载文件")
+                resolver.openOutputStream(uri)?.use { it.write(bytes) }
+                    ?: error("无法写入文件")
+                values.clear()
+                values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+                resolver.update(uri, values, null, null)
+                "Download/$fileName"
+            } else {
+                @Suppress("DEPRECATION")
+                val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                if (!dir.exists()) dir.mkdirs()
+                val file = File(dir, fileName)
+                FileOutputStream(file).use { it.write(bytes) }
+                file.absolutePath
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -21,10 +21,17 @@
     <string name="subtitle_source">源语言</string>
     <string name="subtitle_target">目标语言</string>
     <string name="subtitle_preview">最近预览</string>
-    <string name="subtitle_open_settings">字幕样式 / API 设置</string>
     <string name="subtitle_pick_source">选择源语言</string>
     <string name="subtitle_pick_target">选择目标语言</string>
     <string name="subtitle_selected">已选</string>
+    <string name="subtitle_audio_source">声音来源</string>
+    <string name="audio_source_media">媒体音</string>
+    <string name="audio_source_mic">麦克风音</string>
+    <string name="audio_source_both">媒体音 + 麦克风音</string>
+    <string name="subtitle_export_md">导出本次翻译为 Markdown</string>
+    <string name="subtitle_export_ok">已保存到下载：%1$s</string>
+    <string name="subtitle_export_fail">导出失败：%1$s</string>
+    <string name="subtitle_export_empty">没有可导出的内容</string>
 
     <string name="status_idle">空闲</string>
     <string name="status_starting">启动中</string>
@@ -38,11 +45,15 @@
     <string name="settings_api_desc">默认对接 Google AI Studio Live Translate。可自定义兼容端点。</string>
     <string name="settings_endpoint">API 端点</string>
     <string name="settings_api_key">API Key</string>
+    <string name="settings_api_key_n">API Key %1$d</string>
+    <string name="settings_api_keys_hint">最多 10 个 Key，启动会话时按顺序轮询使用。</string>
     <string name="settings_model_id">模型 ID</string>
     <string name="settings_show">显示</string>
     <string name="settings_hide">隐藏</string>
     <string name="settings_save_and_test">保存并测试连接</string>
-    <string name="settings_save_key_only">仅保存 API Key</string>
+    <string name="settings_save_key_only">保存 API Key</string>
+    <string name="settings_add_key">添加</string>
+    <string name="settings_remove_key">删除</string>
     <string name="settings_testing">测试中…</string>
     <string name="settings_appearance">字幕外观</string>
     <string name="settings_font_size">字体大小 %1$d sp · 系统默认字体</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,10 +21,17 @@
     <string name="subtitle_source">Source</string>
     <string name="subtitle_target">Target</string>
     <string name="subtitle_preview">Recent preview</string>
-    <string name="subtitle_open_settings">Subtitle style / API settings</string>
     <string name="subtitle_pick_source">Select source language</string>
     <string name="subtitle_pick_target">Select target language</string>
     <string name="subtitle_selected">Selected</string>
+    <string name="subtitle_audio_source">Audio source</string>
+    <string name="audio_source_media">Media</string>
+    <string name="audio_source_mic">Microphone</string>
+    <string name="audio_source_both">Media + Microphone</string>
+    <string name="subtitle_export_md">Export this session as Markdown</string>
+    <string name="subtitle_export_ok">Saved to Downloads: %1$s</string>
+    <string name="subtitle_export_fail">Export failed: %1$s</string>
+    <string name="subtitle_export_empty">Nothing to export</string>
 
     <string name="status_idle">Idle</string>
     <string name="status_starting">Starting</string>
@@ -38,11 +45,15 @@
     <string name="settings_api_desc">Default is Google AI Studio Live Translate. Compatible endpoints are supported.</string>
     <string name="settings_endpoint">API endpoint</string>
     <string name="settings_api_key">API Key</string>
+    <string name="settings_api_key_n">API Key %1$d</string>
+    <string name="settings_api_keys_hint">Add up to 10 keys. Sessions rotate keys in order.</string>
     <string name="settings_model_id">Model ID</string>
     <string name="settings_show">Show</string>
     <string name="settings_hide">Hide</string>
     <string name="settings_save_and_test">Save and test connection</string>
-    <string name="settings_save_key_only">Save API Key only</string>
+    <string name="settings_save_key_only">Save API keys</string>
+    <string name="settings_add_key">Add</string>
+    <string name="settings_remove_key">Remove</string>
     <string name="settings_testing">Testing…</string>
     <string name="settings_appearance">Subtitle appearance</string>
     <string name="settings_font_size">Font size %1$d sp · system default font</string>


### PR DESCRIPTION
## 改了什么

- 字幕页增加声音来源：媒体音 / 麦克风 / 媒体+麦克风（麦克风模式不弹录屏）
- 设置页支持最多 10 个 API Key（`+` / `−`），开会话时按顺序轮询；「保存并测试」会测完每一个 Key
- 停止字幕后可把本次原文+译文导出成 Markdown，存到下载目录（文件名如 `7月15日-14:30-翻译结果.md`）
- 深色模式下输入框文字/光标改为用 onSurface，避免看不清
- 去掉字幕页底下那个跳设置的按钮（走底栏设置即可）

## 怎么测

- 三种音源各跑一遍，确认权限弹窗符合预期（只有媒体相关才录屏）
- 填 2 个以上 Key，点测试，应看到每条 Key 的结果，而不是测到第一个成功就停
- 翻一段再停，导出 MD，到下载里打开看原文/译文两段
- 开系统深色模式看设置页输入框是否正常